### PR TITLE
Update C0.tmLanguage

### DIFF
--- a/C0.tmLanguage
+++ b/C0.tmLanguage
@@ -1,5 +1,4 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<!DOCTYPE plist PUBLIC "-//Apple Computer//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
 	<key>fileTypes</key>
@@ -7,61 +6,481 @@
 		<string>c0</string>
 		<string>h0</string>
 	</array>
+	<key>scopeName</key>
+	<string>source.c0</string>
+	<key>uuid</key>
+	<string>5b46c5ee-132d-4b3b-8eb8-98a197bc7480</string>
 	<key>name</key>
 	<string>C0</string>
 	<key>patterns</key>
 	<array>
 		<dict>
 			<key>comment</key>
-			<string>types identifier</string>
-			<key>match</key>
-			<string>(int|bool|char|string|struct|void|typedef)\s</string>
+			<string>Keyword - Iteration</string>
+			<key>begin</key>
+			<string>(else\s+if|if|while|for)\s*(\()</string>
+			<key>beginCaptures</key>
+			<dict>
+				<key>1</key>
+				<dict>
+					<key>name</key>
+					<string>keyword.control.source.c0</string>
+				</dict>
+				<key>2</key>
+				<dict>
+					<key>name</key>
+					<string>variable.other.source.c0</string>
+				</dict>
+			</dict>
+			<key>patterns</key>
+			<array>
+				<dict>
+					<key>include</key>
+					<string>$self</string>
+				</dict>
+				<dict>
+					<key>name</key>
+					<string>source.c0</string>
+					<key>match</key>
+					<string>.</string>
+				</dict>
+			</array>
+			<key>end</key>
+			<string>(\))</string>
+			<key>endCaptures</key>
+			<dict>
+				<key>1</key>
+				<dict>
+					<key>name</key>
+					<string>variable.other.source.co</string>
+				</dict>
+			</dict>
 			<key>name</key>
-			<string>support.type.c0</string>
+			<string>source.c0</string>
 		</dict>
 		<dict>
 			<key>comment</key>
-			<string>types[] identifier</string>
+			<string>Keyword - Control</string>
 			<key>match</key>
-			<string>(int|bool|char|string|void)\[[A-Za-z0-9_]*\]</string>
-			<key>name</key>
-			<string>support.type.c0</string>
-		</dict>
-		<dict>
-			<key>comment</key>
-			<string>Constants identifier</string>
-			<key>match</key>
-			<string>(NULL|true|false|alloc|alloc_array|&amp;&amp;|\|\|)</string>
-			<key>name</key>
-			<string>constant.language.c0</string>
-		</dict>
-		<dict>
-			<key>comment</key>
-			<string>HEXdecimal identifier</string>
-			<key>match</key>
-			<string>0[xX][A-Za-z0-9_]+</string>
-			<key>name</key>
-			<string>constant.language.c0</string>
-		</dict>
-		<dict>
-			<key>comment</key>
-			<string>control identifier</string>
-			<key>match</key>
-			<string>(if|else|while|for|return|continue|break|assert|error)</string>
+			<string>(else|return|continue|break)</string>
 			<key>name</key>
 			<string>keyword.control.c0</string>
 		</dict>
 		<dict>
 			<key>comment</key>
-			<string>string identifier</string>
+			<string>Directives - Preprocessor</string>
 			<key>match</key>
-			<string>("|&lt;).*?("|&gt;)</string>
+			<string>(#)(\w+)\s+([&lt;"]\w+\.?c?0?[&gt;"])</string>
+			<key>captures</key>
+			<dict>
+				<key>1</key>
+				<dict>
+					<key>name</key>
+					<string>keyword.control.source.c0</string>
+				</dict>
+				<key>2</key>
+				<dict>
+					<key>name</key>
+					<string>constant.language.source.c0</string>
+				</dict>
+				<key>3</key>
+				<dict>
+					<key>name</key>
+					<string>support.function.source.c0</string>
+				</dict>
+			</dict>
 			<key>name</key>
-			<string>string.quoted.double.c0</string>
+			<string>keyword.source.c0</string>
 		</dict>
 		<dict>
 			<key>comment</key>
-			<string>comment identifier</string>
+			<string>Type - Typedef</string>
+			<key>match</key>
+			<string>(typedef)\s+</string>
+			<key>name</key>
+			<string>entity.name.function.source.c0</string>
+		</dict>
+		<dict>
+			<key>comment</key>
+			<string>Scope - Bracket</string>
+			<key>match</key>
+			<string>[\{\}]</string>
+			<key>name</key>
+			<string>variable.other.source.c0</string>
+		</dict>
+		<dict>
+			<key>comment</key>
+			<string>Function - Definition</string>
+			<key>begin</key>
+			<string>(\w+)([\[\*]?\]?)\s+([A-Za-z_][A-Za-z0-9_]*)\s*(\()</string>
+			<key>beginCaptures</key>
+			<dict>
+				<key>1</key>
+				<dict>
+					<key>name</key>
+					<string>storage.type.source.c0</string>
+				</dict>
+				<key>2</key>
+				<dict>
+					<key>name</key>
+					<string>storage.type.source.c0</string>
+				</dict>
+				<key>3</key>
+				<dict>
+					<key>name</key>
+					<string>entity.name.function.source.c0</string>
+				</dict>
+				<key>4</key>
+				<dict>
+					<key>name</key>
+					<string>variable.other.source.c0</string>
+				</dict>
+			</dict>
+			<key>end</key>
+			<string>(\))</string>
+			<key>endCaptures</key>
+			<dict>
+				<key>1</key>
+				<dict>
+					<key>name</key>
+					<string>variable.other.source.c0</string>
+				</dict>
+			</dict>
+			<key>patterns</key>
+			<array>
+				<dict>
+					<key>comment</key>
+					<string>Function - Arguments</string>
+					<key>begin</key>
+					<string>\b(struct \w+|\w+)([\[\*]?\]?)</string>
+					<key>beginCaptures</key>
+					<dict>
+						<key>1</key>
+						<dict>
+							<key>name</key>
+							<string>keyword.other.source.c0</string>
+						</dict>
+						<key>2</key>
+						<dict>
+							<key>name</key>
+							<string>keyword.other.source.c0</string>
+						</dict>
+						<key>3</key>
+						<dict>
+							<key>name</key>
+							<string>entity.name.tag.source.c0</string>
+						</dict>
+					</dict>
+					<key>end</key>
+					<string>\b([A-Za-z_][A-Za-z0-9_]*),?\b</string>
+					<key>endCaptures</key>
+					<dict>
+						<key>1</key>
+						<dict>
+							<key>name</key>
+							<string>variable.parameter.function.source.c0</string>
+						</dict>
+					</dict>
+				</dict>
+				<dict>
+					<key>name</key>
+					<string>source.c0</string>
+					<key>match</key>
+					<string>.</string>
+				</dict>
+				<dict>
+					<key>include</key>
+					<string>$self</string>
+				</dict>
+			</array>
+			<key>contentName</key>
+			<string>source.c0</string>
+			<key>name</key>
+			<string>source.c0</string>
+		</dict>
+		<dict>
+			<key>comment</key>
+			<string>Structure - Definition</string>
+			<key>begin</key>
+			<string>\b(struct)\s+([A-Za-z_][\w\d_]*\*?\[?\]?)[\s\n]*(\{)</string>
+			<key>beginCaptures</key>
+			<dict>
+				<key>1</key>
+				<dict>
+					<key>name</key>
+					<string>storage.source.c0</string>
+				</dict>
+				<key>2</key>
+				<dict>
+					<key>name</key>
+					<string>storage.type.source.c0</string>
+				</dict>
+				<key>3</key>
+				<dict>
+					<key>name</key>
+					<string>variable.other.source.c0</string>
+				</dict>
+			</dict>
+			<key>patterns</key>
+			<array>
+				<dict>
+					<key>comment</key>
+					<string>Structure - Fields</string>
+					<key>begin</key>
+					<string>\b(struct \w+|\w+)([\[\*]?\]?)\s+</string>
+					<key>beginCaptures</key>
+					<dict>
+						<key>1</key>
+						<dict>
+							<key>name</key>
+							<string>keyword.other.source.c0</string>
+						</dict>
+						<key>2</key>
+						<dict>
+							<key>name</key>
+							<string>keyword.other.source.c0</string>
+						</dict>
+						<key>3</key>
+						<dict>
+							<key>name</key>
+							<string>entity.name.tag.source.c0</string>
+						</dict>
+					</dict>
+					<key>end</key>
+					<string>\b([A-Za-z_][A-Za-z0-9_]*)(;)</string>
+					<key>endCaptures</key>
+					<dict>
+						<key>1</key>
+						<dict>
+							<key>name</key>
+							<string>entity.name.tag.source.c0</string>
+						</dict>
+						<key>2</key>
+						<dict>
+							<key>name</key>
+							<string>variable.other.source.c0</string>
+						</dict>
+					</dict>
+				</dict>
+				<dict>
+					<key>comment</key>
+					<string>Structure - Nested</string>
+					<key>begin</key>
+					<string>\b(struct)\s+([A-Za-z_][\w\d_]*\*?\[?\]?)[\s\n]*</string>
+					<key>beginCaptures</key>
+					<dict>
+						<key>1</key>
+						<dict>
+							<key>name</key>
+							<string>storage.source.c0</string>
+						</dict>
+						<key>2</key>
+						<dict>
+							<key>name</key>
+							<string>constant.other.source.c0</string>
+						</dict>
+						<key>3</key>
+						<dict>
+							<key>name</key>
+							<string>entity.name.tag.source.c0</string>
+						</dict>
+					</dict>
+					<key>end</key>
+					<string>\b([A-Za-z_][A-Za-z0-9_]*)(;)</string>
+					<key>endCaptures</key>
+					<dict>
+						<key>1</key>
+						<dict>
+							<key>name</key>
+							<string>entity.name.tag.source.c0</string>
+						</dict>
+						<key>2</key>
+						<dict>
+							<key>name</key>
+							<string>variable.other.source.c0</string>
+						</dict>
+					</dict>
+				</dict>
+				<dict>
+					<key>include</key>
+					<string>$self</string>
+				</dict>
+				<dict>
+					<key>name</key>
+					<string>source.c0</string>
+					<key>match</key>
+					<string>.</string>
+				</dict>
+			</array>
+			<key>end</key>
+			<string>(\})</string>
+			<key>endCaptures</key>
+			<dict>
+				<key>1</key>
+				<dict>
+					<key>name</key>
+					<string>variable.other.source.c0</string>
+				</dict>
+			</dict>
+			<key>name</key>
+			<string>constant.language.source.c0</string>
+		</dict>
+		<dict>
+			<key>comment</key>
+			<string>Structure - Member</string>
+			<key>match</key>
+			<string>(\-&gt;)\s*(\w+)</string>
+			<key>captures</key>
+			<dict>
+				<key>1</key>
+				<dict>
+					<key>name</key>
+					<string>keyword.other.source.c0</string>
+				</dict>
+				<key>2</key>
+				<dict>
+					<key>name</key>
+					<string>entity.name.tag.source.c0</string>
+				</dict>
+			</dict>
+			<key>name</key>
+			<string>constant.language.source.c0</string>
+		</dict>
+		<dict>
+			<key>comment</key>
+			<string>Structure - Reference</string>
+			<key>begin</key>
+			<string>\b(\w+)\s*(\-&gt;)</string>
+			<key>beginCaptures</key>
+			<dict>
+				<key>1</key>
+				<dict>
+					<key>name</key>
+					<string>source.c0</string>
+				</dict>
+				<key>2</key>
+				<dict>
+					<key>name</key>
+					<string>variable.source.c0</string>
+				</dict>
+			</dict>
+			<key>end</key>
+			<string>(\w+|\n)</string>
+			<key>endCaptures</key>
+			<dict>
+				<key>1</key>
+				<dict>
+					<key>name</key>
+					<string>entity.name.tag.source.c0</string>
+				</dict>
+			</dict>
+			<key>name</key>
+			<string>source.c0</string>
+		</dict>
+		<dict>
+			<key>comment</key>
+			<string>Structure - Reference</string>
+			<key>match</key>
+			<string>\b(struct)\s+([A-Za-z_][\w\d_]*\*?\[?\]?)[\s\n]*</string>
+			<key>captures</key>
+			<dict>
+				<key>1</key>
+				<dict>
+					<key>name</key>
+					<string>storage.source.c0</string>
+				</dict>
+				<key>2</key>
+				<dict>
+					<key>name</key>
+					<string>storage.type.source.c0</string>
+				</dict>
+			</dict>
+		</dict>
+		<dict>
+			<key>comment</key>
+			<string>Type - Declaration</string>
+			<key>begin</key>
+			<string>([A-Za-z_][\w\d]*\[?\]?)\s+(\w+)\s*(=)</string>
+			<key>beginCaptures</key>
+			<dict>
+				<key>1</key>
+				<dict>
+					<key>name</key>
+					<string>support.type.source.c0</string>
+				</dict>
+				<key>2</key>
+				<dict>
+					<key>name</key>
+					<string>entity.name.class.source.c0</string>
+				</dict>
+				<key>3</key>
+				<dict>
+					<key>name</key>
+					<string>constant.language.source.c0</string>
+				</dict>
+			</dict>
+			<key>patterns</key>
+			<array>
+				<dict>
+					<key>include</key>
+					<string>$self</string>
+				</dict>
+				<dict>
+					<key>name</key>
+					<string>source.c0</string>
+					<key>match</key>
+					<string>.</string>
+				</dict>
+			</array>
+			<key>end</key>
+			<string>;</string>
+			<key>name</key>
+			<string>source.c0</string>
+		</dict>
+		<dict>
+			<key>comment</key>
+			<string>Type - Pointer Declaration</string>
+			<key>begin</key>
+			<string>([A-Za-z_][\w\d]*\*)\s+(\w+)\s*(=)</string>
+			<key>beginCaptures</key>
+			<dict>
+				<key>1</key>
+				<dict>
+					<key>name</key>
+					<string>variable.source.c0</string>
+				</dict>
+				<key>2</key>
+				<dict>
+					<key>name</key>
+					<string>entity.name.class.source.c0</string>
+				</dict>
+				<key>3</key>
+				<dict>
+					<key>name</key>
+					<string>constant.language.source.c0</string>
+				</dict>
+			</dict>
+			<key>patterns</key>
+			<array>
+				<dict>
+					<key>include</key>
+					<string>$self</string>
+				</dict>
+				<dict>
+					<key>name</key>
+					<string>source.c0</string>
+					<key>match</key>
+					<string>.</string>
+				</dict>
+			</array>
+			<key>end</key>
+			<string>;</string>
+			<key>name</key>
+			<string>source.c0</string>
+		</dict>
+		<dict>
+			<key>comment</key>
+			<string>Annotation - Comment</string>
 			<key>match</key>
 			<string>//(?!@).*</string>
 			<key>name</key>
@@ -78,17 +497,33 @@
 			<array>
 				<dict>
 					<key>comment</key>
-					<string>block comment identifier</string>
+					<string>Annotation - Block Comment</string>
 					<key>match</key>
 					<string>.</string>
 					<key>name</key>
 					<string>comment.block.c0</string>
 				</dict>
+				<dict>
+					<key>comment</key>
+					<string>Annotation - Highlight</string>
+					<key>match</key>
+					<string>\*\|\-\.</string>
+					<key>name</key>
+					<string>comment.c0</string>
+				</dict>
 			</array>
 		</dict>
 		<dict>
 			<key>comment</key>
-			<string>line-annotations identifier</string>
+			<string>Annotation - Contract</string>
+			<key>match</key>
+			<string>/[/\*]@(requires|ensures|loop_invariant|assert)\s|@\*/</string>
+			<key>name</key>
+			<string>keyword.storage.source.c0</string>
+		</dict>
+		<dict>
+			<key>comment</key>
+			<string>Annotation - Block Contract</string>
 			<key>match</key>
 			<string>//@.*</string>
 			<key>name</key>
@@ -96,7 +531,7 @@
 		</dict>
 		<dict>
 			<key>begin</key>
-			<string>/\*@</string>
+			<string>/\*@(requires|ensures|loop_invariant|assert) </string>
 			<key>end</key>
 			<string>@\*/</string>
 			<key>name</key>
@@ -105,7 +540,7 @@
 			<array>
 				<dict>
 					<key>comment</key>
-					<string>block-annotations identifier</string>
+					<string>Annotation - Block Contract</string>
 					<key>match</key>
 					<string>.</string>
 					<key>name</key>
@@ -115,16 +550,196 @@
 		</dict>
 		<dict>
 			<key>comment</key>
-			<string>compiler directives</string>
+			<string>Operator - Binary</string>
 			<key>match</key>
-			<string>#use\s</string>
+			<string>!=|=[=&lt;&gt;]|[&lt;&gt;]=|&amp;&amp;|\|\||&lt;|&gt;</string>
 			<key>name</key>
-			<string>keyword.source.c0</string>
+			<string>constant.other.source.c0</string>
+		</dict>
+		<dict>
+			<key>comment</key>
+			<string>Operator - Assignment</string>
+			<key>match</key>
+			<string>\^|\||&amp;|\-&gt;|\?|:|\%|\+|\-|\*|\/|=|\+\+|\-\-|\*\*|[/\^\*\+\-%&amp;\|]=</string>
+			<key>name</key>
+			<string>constant.language.source.c0</string>
+		</dict>
+		<dict>
+			<key>comment</key>
+			<string>Operator - Unary</string>
+			<key>match</key>
+			<string>!|~|:|\?|%|\-&gt;|\||&amp;|^|&lt;&lt;|&gt;&gt;</string>
+			<key>name</key>
+			<string>constant.language.source.c0</string>
+		</dict>
+		<dict>
+			<key>comment</key>
+			<string>Type - Array Identifier</string>
+			<key>match</key>
+			<string>(\w+)\[\]\s</string>
+			<key>name</key>
+			<string>support.type.source.c0</string>
+		</dict>
+		<dict>
+			<key>comment</key>
+			<string>Type - Pointer Identifier</string>
+			<key>match</key>
+			<string>(\w+)\*\s</string>
+			<key>name</key>
+			<string>variable.source.c0</string>
+		</dict>
+		<dict>
+			<key>comment</key>
+			<string>Type - Identifier</string>
+			<key>match</key>
+			<string>\b(bool|int|char|string)\b</string>
+			<key>name</key>
+			<string>support.type.source.c0</string>
+		</dict>
+		<dict>
+			<key>comment</key>
+			<string>Constant - Integer</string>
+			<key>match</key>
+			<string>\b\d+\b</string>
+			<key>name</key>
+			<string>constant.numeric.source.c0</string>
+		</dict>
+		<dict>
+			<key>comment</key>
+			<string>Constant - Hexadecimal</string>
+			<key>match</key>
+			<string>\b0[Xx][A-Fa-f0-9]?{,8}</string>
+			<key>name</key>
+			<string>constant.numeric.source.c0</string>
+		</dict>
+		<dict>
+			<key>comment</key>
+			<string>Constant - Character</string>
+			<key>begin</key>
+			<string>'</string>
+			<key>end</key>
+			<string>'</string>
+			<key>name</key>
+			<string>string.quoted.double.source.c0</string>
+		</dict>
+		<dict>
+			<key>comment</key>
+			<string>Constant - String</string>
+			<key>begin</key>
+			<string>"</string>
+			<key>end</key>
+			<string>"</string>
+			<key>name</key>
+			<string>string.quoted.double.source.c0</string>
+		</dict>
+		<dict>
+			<key>comment</key>
+			<string>Constant - Literals</string>
+			<key>match</key>
+			<string>\b(void|NULL|null|true|false)\b</string>
+			<key>name</key>
+			<string>constant.language.source.c0</string>
+		</dict>
+		<dict>
+			<key>comment</key>
+			<string>Constant - Builtins</string>
+			<key>match</key>
+			<string>alloc_array|m?alloc|assert|\\(old|length|result)</string>
+			<key>name</key>
+			<string>variable.source.c0</string>
+		</dict>
+		<dict>
+			<key>comment</key>
+			<string>Function - Call</string>
+			<key>begin</key>
+			<string>([A-Za-z_][\w]*)\s*(\()</string>
+			<key>beginCaptures</key>
+			<dict>
+				<key>1</key>
+				<dict>
+					<key>name</key>
+					<string>entity.name.class.source.c0</string>
+				</dict>
+				<key>2</key>
+				<dict>
+					<key>name</key>
+					<string>variable.other.source.c0</string>
+				</dict>
+			</dict>
+			<key>end</key>
+			<string>(\))</string>
+			<key>endCaptures</key>
+			<dict>
+				<key>1</key>
+				<dict>
+					<key>name</key>
+					<string>variable.other.source.c0</string>
+				</dict>
+			</dict>
+			<key>patterns</key>
+			<array>
+				<dict>
+					<key>include</key>
+					<string>$self</string>
+				</dict>
+				<dict>
+					<key>name</key>
+					<string>source.c0</string>
+					<key>match</key>
+					<string>.</string>
+				</dict>
+			</array>
+		</dict>
+		<dict>
+			<key>comment</key>
+			<string>Array - Access</string>
+			<key>begin</key>
+			<string>([A-Za-z_][\w]*)\s*(\[)</string>
+			<key>beginCaptures</key>
+			<dict>
+				<key>1</key>
+				<dict>
+					<key>name</key>
+					<string>storage.source.c0</string>
+				</dict>
+				<key>2</key>
+				<dict>
+					<key>name</key>
+					<string>variable.other.source.c0</string>
+				</dict>
+			</dict>
+			<key>end</key>
+			<string>(\])</string>
+			<key>endCaptures</key>
+			<dict>
+				<key>1</key>
+				<dict>
+					<key>name</key>
+					<string>variable.other.source.c0</string>
+				</dict>
+			</dict>
+			<key>patterns</key>
+			<array>
+				<dict>
+					<key>include</key>
+					<string>$self</string>
+				</dict>
+				<dict>
+					<key>name</key>
+					<string>source.c0</string>
+					<key>match</key>
+					<string>.</string>
+				</dict>
+			</array>
+		</dict>
+		<dict>
+			<key>comment</key>
+			<string>Credits</string>
+			<key>match</key>
+			<string>Ben Scott's Modification for Mahmoud Alismail's C0 Language Scoping</string>
+			<key>name</key>
+			<string>variable.parameter.function.source.c0</string>
 		</dict>
 	</array>
-	<key>scopeName</key>
-	<string>source.c0</string>
-	<key>uuid</key>
-	<string>5b46c5ee-132d-4b3b-8eb8-98a197bc7480</string>
 </dict>
 </plist>


### PR DESCRIPTION
Completely generic types, added fancy things for struct operations, function arguments, and variable declarations. Also, now it doesn't break the highlighting to do else if (), because the else capture comes before the function definition capture, whereas before it thought else was the type and if was the function name. Also fixed the hex literal capture, now it uses curly braces to indicate the number of repetitions. The function arguments are poorly delimited, but if the syntax is correct, they're ok. I would add an end clause for the newline character if function declarations always fit onto one line, as it is, I don't know how to fix it.
